### PR TITLE
devデプロイ時のBASEURL修正、ライセンス追記

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright © 2020 T.Fujiba(@fujiba)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -135,3 +135,7 @@ firebaseのデプロイを行うための、GCPサービスアカウントのキ
 gh secret set GOOGLE_APPLICATION_CREDENTIALS --body '/tmp/cred.json'
 gh secret set GCLOUD_SERVICE_KEY < terraform/environments/{構築対象環境}/output/secrets/deployuser-key
 ```
+
+## Lisence
+
+This project is licensed under the MIT License, see the LICENSE.txt file for details

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Boilerplate for Firebase with Hugo contents.",
   "scripts": {
     "deploy:prod": "(cd website && hugo --minify) && firebase deploy --only hosting:prod",
-    "deploy:dev": "scripts/deploy-dev.sh"
+    "deploy:dev": "scripts/deploy-dev.sh",
+    "serve": "(cd website && hugo server)"
   },
   "author": "T.Fujiba",
   "license": "MIT",

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
-set eu
+set -eu
 
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 PROJECT_DIR=$(cd $(dirname ${SCRIPT_DIR}); pwd)
 DIST_DIR=${PROJECT_DIR}/dist
 
+PROJECT_ID=`yq '.firebase.projectId' ${PROJECT_DIR}/config.yaml`
+
 echo "create web contents..."
-(cd ${PROJECT_DIR}/website && hugo)
+
+(cd ${PROJECT_DIR}/website && HUGO_BASEURL="https://dev-${PROJECT_ID}.web.app/" hugo --minify)
 
 if [ -e ${DIST_DIR} ]; then
    rm -rf ${DIST_DIR}


### PR DESCRIPTION
## devデプロイ時のBASEURLを設定できるようにした

npm run deploy:devの際、hugoのBASE URLを`https://dev-{projectId}.web.app/` となるようにした。（環境変数による設定)

## その他

* ライセンス記載漏れ対応
* npm run serveでhugoをローカルで起動