### PR TITLE
v0.0.2向け: dev環境デプロイでBASEURL設定、ライセンス追記

### DIFF
--- a/.github/workflows/deploy-develop.yaml
+++ b/.github/workflows/deploy-develop.yaml
@@ -6,32 +6,56 @@ on:
     branches:
       - develop
     paths:
-      - "functions/**"
-      - "website/**"
+      - 'functions/**'
+      - 'website/**'
 
 jobs:
-  build_and_deploy:
-    name: Call hugo and deploy to firebase.
+  confirm_pre_conditions:
+    name: Confirm pre-conditons for continue build&deploy job.
     runs-on: ubuntu-latest
     env:
-      GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
       GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+    outputs:
+      skip_ci: ${{ steps.confirmEnvValues.outputs.value }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          submodules: true # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
       - name: Get setting for continue this workflow
         id: lookupDeployOnCommitDevelop
         uses: mikefarah/yq@master
         with:
           cmd: yq '.setup.deployOnCommitDevelop' 'config.yaml'
-      - name: ${{ steps.act.outputs.selected }}
-        if: steps.lookupDeployOnCommitDevelop.outputs.selected == 'true'
+      - name: Confirm environment values
+        id: confirmEnvValues
         run: |
-          echo "Deploy was skipped because deployOnCommitDevelop is true"
-          exit 1
+          if [ -z $GCLOUD_SERVICE_KEY ]; then
+            echo "GCLOUD_SERVICE_KEY is not set"
+            echo "value=true" >> $GITHUB_OUTPUT
+          elif [ '${{steps.lookupDeployOnCommitDevelop.outputs.result }}' != 'true' ]; then
+            echo "deployOnCommitDevelop was set false"
+            echo "value=true" >> $GITHUB_OUTPUT
+          else
+            echo "value=false" >> $GITHUB_OUTPUT
+          fi
+  build_and_deploy:
+    name: Call hugo and deploy to firebase.
+    needs: confirm_pre_conditions
+    if: ${{ needs.confirm_pre_conditions.outputs.skip_ci != 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+      GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+    steps:
+      - name: debug
+        run: |
+          echo "${{ needs.confirm_pre_conditions.outputs.skip_ci }}"
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
       - name: Get Hugo Version from config
         id: lookupHugoVersion
         uses: mikefarah/yq@master

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -6,12 +6,31 @@ on:
     branches:
       - main
     paths:
-      - "website/**"
+      - 'website/**'
 
 jobs:
+  confirm_pre_conditions:
+    name: Confirm pre-conditons for continue build&deploy job.
+    runs-on: ubuntu-latest
+    env:
+      GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+    outputs:
+      skip_ci: ${{ steps.confirmEnvValues.outputs.value }}
+    steps:
+      - name: Confirm environment values
+        id: confirmEnvValues
+        run: |
+          if [ -z $GCLOUD_SERVICE_KEY ]; then
+            echo "GCLOUD_SERVICE_KEY is not set"
+            echo "value=true" >> $GITHUB_OUTPUT
+          else
+            echo "value=false" >> $GITHUB_OUTPUT
+          fi
   build_and_deploy:
     name: Call hugo and deploy to firebase.
     runs-on: ubuntu-latest
+    needs: confirm_pre_conditions
+    if: ${{ needs.confirm_pre_conditions.outputs.skip_ci != 'true' }}
     env:
       GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
       GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 setup:
   hugoVersion: latest
-  deployOnCommitDevelop: true
+  deployOnCommitDevelop: false
 firebase:
-  projectId: {YOUR FIREBASE PROJECT ID HERE}
-  projectName: {YOUR FIREBASE PROJECT DISPLAYNAME HERE}
+  projectId: { YOUR FIREBASE PROJECT ID HERE }
+  projectName: { YOUR FIREBASE PROJECT DISPLAYNAME HERE }


### PR DESCRIPTION

## devデプロイ時のBASEURLを設定できるようにした

npm run deploy:devの際、hugoのBASE URLをhttps://dev-{projectId}.web.app/ となるようにした。（環境変数による設定)

## その他

- ライセンス記載漏れ対応
- npm run serveでhugoをローカルで起動

